### PR TITLE
[codex] Stabilize Lexa Slay learning hub

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,8 @@
 :root {
   --background: #fff8ef;
   --foreground: #1f2937;
+  --font-heading: "Trebuchet MS", "Arial Rounded MT Bold", system-ui, sans-serif;
+  --font-body: "Nunito", "Segoe UI", system-ui, sans-serif;
 }
 
 @theme inline {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,17 +1,6 @@
 import type { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/next";
-import { Fredoka, Nunito } from "next/font/google";
 import "./globals.css";
-
-const fredoka = Fredoka({
-  variable: "--font-heading",
-  subsets: ["latin"],
-});
-
-const nunito = Nunito({
-  variable: "--font-body",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Lexa Slay Math Quest",
@@ -24,10 +13,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html
-      lang="en"
-      className={`${fredoka.variable} ${nunito.variable} h-full antialiased`}
-    >
+    <html lang="en" className="h-full antialiased">
       <body className="min-h-full flex flex-col font-[family-name:var(--font-body)]">
         {children}
         <Analytics />

--- a/components/lexa-slay-learning-hub.tsx
+++ b/components/lexa-slay-learning-hub.tsx
@@ -6,9 +6,16 @@ import { BookOpen, Crown, Medal, Sparkles, SpellCheck, Star, Trophy, Users } fro
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
+import {
+  SPELLING_MODES,
+  getAllSpellingWords,
+  getSpellingWordsForDifficulty,
+  type SpellingDifficulty,
+  type SpellingMode,
+} from "@/lib/spelling-inventory";
 
 type Activity = "math" | "spelling";
-type Difficulty = "Starter" | "Builder" | "Challenge";
+type Difficulty = SpellingDifficulty;
 
 type ScoreRecord = {
   id: string;
@@ -28,12 +35,6 @@ type MathQuestion = {
   tip: string;
 };
 
-type SpellingWord = {
-  word: string;
-  difficulty: Difficulty;
-  clue: string;
-};
-
 const SCOREBOARD_KEY = "lexa-slay-scoreboard-v1";
 const PLAYER_KEY = "lexa-slay-current-player-v1";
 
@@ -50,106 +51,24 @@ const MATH_QUESTIONS: MathQuestion[] = [
   { prompt: "School starts at 8:00 and ends at 3:00. How many hours is that?", choices: ["5", "6", "7", "8"], answer: "7", tip: "Count from 8 to 3." },
 ];
 
-const SPELLING_WORDS: SpellingWord[] = [
-  { word: "about", difficulty: "Starter", clue: "Concerning something" },
-  { word: "again", difficulty: "Starter", clue: "One more time" },
-  { word: "always", difficulty: "Starter", clue: "Every time" },
-  { word: "answer", difficulty: "Starter", clue: "A reply or solution" },
-  { word: "because", difficulty: "Starter", clue: "For the reason that" },
-  { word: "before", difficulty: "Starter", clue: "Earlier than" },
-  { word: "better", difficulty: "Starter", clue: "More good" },
-  { word: "between", difficulty: "Starter", clue: "In the middle of two things" },
-  { word: "brought", difficulty: "Starter", clue: "Carried with you" },
-  { word: "caught", difficulty: "Starter", clue: "Grabbed or captured" },
-  { word: "different", difficulty: "Starter", clue: "Not the same" },
-  { word: "enough", difficulty: "Starter", clue: "As much as needed" },
-  { word: "favorite", difficulty: "Starter", clue: "Liked the most" },
-  { word: "friend", difficulty: "Starter", clue: "Someone you like and trust" },
-  { word: "important", difficulty: "Starter", clue: "Matters a lot" },
-  { word: "inside", difficulty: "Starter", clue: "Within something" },
-  { word: "minute", difficulty: "Starter", clue: "Sixty seconds" },
-  { word: "people", difficulty: "Starter", clue: "More than one person" },
-  { word: "picture", difficulty: "Starter", clue: "A drawing or photo" },
-  { word: "sentence", difficulty: "Starter", clue: "A group of words with a complete idea" },
-  { word: "through", difficulty: "Starter", clue: "From one side to the other" },
-  { word: "usually", difficulty: "Starter", clue: "Most of the time" },
-  { word: "weather", difficulty: "Starter", clue: "Rain, sun, wind, and storms" },
-  { word: "without", difficulty: "Starter", clue: "Not having something" },
-  { word: "although", difficulty: "Builder", clue: "Even though" },
-  { word: "beautiful", difficulty: "Builder", clue: "Very pretty" },
-  { word: "believe", difficulty: "Builder", clue: "To think something is true" },
-  { word: "business", difficulty: "Builder", clue: "A company or trade" },
-  { word: "calendar", difficulty: "Builder", clue: "Tracks days, weeks, and months" },
-  { word: "careful", difficulty: "Builder", clue: "Doing something with caution" },
-  { word: "certain", difficulty: "Builder", clue: "Sure or specific" },
-  { word: "complete", difficulty: "Builder", clue: "Finished" },
-  { word: "continue", difficulty: "Builder", clue: "Keep going" },
-  { word: "describe", difficulty: "Builder", clue: "Tell what something is like" },
-  { word: "direction", difficulty: "Builder", clue: "A way to go or an instruction" },
-  { word: "discover", difficulty: "Builder", clue: "Find something new" },
-  { word: "exercise", difficulty: "Builder", clue: "Activity for your body" },
-  { word: "favorite", difficulty: "Builder", clue: "Liked the most" },
-  { word: "finally", difficulty: "Builder", clue: "At last" },
-  { word: "history", difficulty: "Builder", clue: "Events from the past" },
-  { word: "imagine", difficulty: "Builder", clue: "Picture in your mind" },
-  { word: "language", difficulty: "Builder", clue: "Words people use to communicate" },
-  { word: "library", difficulty: "Builder", clue: "A place with books" },
-  { word: "measure", difficulty: "Builder", clue: "Find the size or amount" },
-  { word: "natural", difficulty: "Builder", clue: "From nature" },
-  { word: "possible", difficulty: "Builder", clue: "Can happen" },
-  { word: "probably", difficulty: "Builder", clue: "Likely" },
-  { word: "question", difficulty: "Builder", clue: "Something you ask" },
-  { word: "remember", difficulty: "Builder", clue: "Keep in your mind" },
-  { word: "separate", difficulty: "Builder", clue: "To keep apart" },
-  { word: "special", difficulty: "Builder", clue: "Not ordinary" },
-  { word: "straight", difficulty: "Builder", clue: "Not curved" },
-  { word: "surprise", difficulty: "Builder", clue: "Something unexpected" },
-  { word: "therefore", difficulty: "Builder", clue: "For that reason" },
-  { word: "whether", difficulty: "Builder", clue: "Used when comparing choices" },
-  { word: "accident", difficulty: "Challenge", clue: "Something that happens by mistake" },
-  { word: "actually", difficulty: "Challenge", clue: "Really or truly" },
-  { word: "adventure", difficulty: "Challenge", clue: "An exciting experience" },
-  { word: "attention", difficulty: "Challenge", clue: "Focused listening or watching" },
-  { word: "audience", difficulty: "Challenge", clue: "People watching or listening" },
-  { word: "available", difficulty: "Challenge", clue: "Ready to use" },
-  { word: "community", difficulty: "Challenge", clue: "A group of people in one area" },
-  { word: "confidence", difficulty: "Challenge", clue: "Believing you can do it" },
-  { word: "courageous", difficulty: "Challenge", clue: "Brave" },
-  { word: "curiosity", difficulty: "Challenge", clue: "Wanting to learn or know" },
-  { word: "dangerous", difficulty: "Challenge", clue: "Not safe" },
-  { word: "decision", difficulty: "Challenge", clue: "A choice" },
-  { word: "delicious", difficulty: "Challenge", clue: "Very tasty" },
-  { word: "dictionary", difficulty: "Challenge", clue: "A book or site with word meanings" },
-  { word: "embarrass", difficulty: "Challenge", clue: "To make someone feel awkward" },
-  { word: "especially", difficulty: "Challenge", clue: "More than usual" },
-  { word: "experience", difficulty: "Challenge", clue: "Something you do or live through" },
-  { word: "experiment", difficulty: "Challenge", clue: "A science test" },
-  { word: "government", difficulty: "Challenge", clue: "The people who run a city, state, or country" },
-  { word: "guarantee", difficulty: "Challenge", clue: "A promise" },
-  { word: "immediately", difficulty: "Challenge", clue: "Right away" },
-  { word: "independent", difficulty: "Challenge", clue: "Able to do things on your own" },
-  { word: "knowledge", difficulty: "Challenge", clue: "What you know" },
-  { word: "necessary", difficulty: "Challenge", clue: "Needed" },
-  { word: "occasion", difficulty: "Challenge", clue: "A special event or time" },
-  { word: "opportunity", difficulty: "Challenge", clue: "A chance" },
-  { word: "organization", difficulty: "Challenge", clue: "A group or the act of arranging things" },
-  { word: "particular", difficulty: "Challenge", clue: "Specific" },
-  { word: "performance", difficulty: "Challenge", clue: "How well someone does" },
-  { word: "recommend", difficulty: "Challenge", clue: "Suggest as a good choice" },
-  { word: "responsible", difficulty: "Challenge", clue: "Trusted to handle something" },
-  { word: "schedule", difficulty: "Challenge", clue: "A plan for when things happen" },
-  { word: "successful", difficulty: "Challenge", clue: "Having a good result" },
-  { word: "temperature", difficulty: "Challenge", clue: "How hot or cold something is" },
-  { word: "understand", difficulty: "Challenge", clue: "To know what something means" },
-  { word: "wonderful", difficulty: "Challenge", clue: "Very good" },
-];
-
 function shuffle<T>(items: T[]) {
   return [...items].sort(() => Math.random() - 0.5);
 }
 
 function normalize(value: string) {
   return value.trim().toLowerCase();
+}
+
+function createScoreId() {
+  if (typeof window !== "undefined" && window.crypto?.randomUUID) {
+    return window.crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function getScoreDate() {
+  return new Date().toLocaleDateString();
 }
 
 function loadScores(): ScoreRecord[] {
@@ -171,9 +90,9 @@ export default function LexaSlayLearningHub() {
   const [pendingName, setPendingName] = useState(getStoredPlayer);
   const [scores, setScores] = useState<ScoreRecord[]>(loadScores);
   const [activity, setActivity] = useState<Activity | null>(null);
-  const [difficulty, setDifficulty] = useState<Difficulty | "Mixed">("Mixed");
+  const [difficulty, setDifficulty] = useState<SpellingMode>("Mixed");
   const [mathQuestions, setMathQuestions] = useState(() => shuffle(MATH_QUESTIONS));
-  const [spellingWords, setSpellingWords] = useState(() => shuffle(SPELLING_WORDS));
+  const [spellingWords, setSpellingWords] = useState(() => shuffle(getAllSpellingWords()));
   const [index, setIndex] = useState(0);
   const [score, setScore] = useState(0);
   const [correct, setCorrect] = useState(0);
@@ -216,7 +135,7 @@ export default function LexaSlayLearningHub() {
     window.localStorage.setItem(PLAYER_KEY, cleanName);
   }
 
-  function startActivity(nextActivity: Activity, nextDifficulty: Difficulty | "Mixed" = "Mixed") {
+  function startActivity(nextActivity: Activity, nextDifficulty: SpellingMode = "Mixed") {
     if (!playerName.trim()) {
       setFeedback("Enter your name first so your score counts.");
       return;
@@ -235,21 +154,21 @@ export default function LexaSlayLearningHub() {
     if (nextActivity === "math") {
       setMathQuestions(shuffle(MATH_QUESTIONS));
     } else {
-      const pool = nextDifficulty === "Mixed" ? SPELLING_WORDS : SPELLING_WORDS.filter((word) => word.difficulty === nextDifficulty);
+      const pool = nextDifficulty === "Mixed" ? getAllSpellingWords() : getSpellingWordsForDifficulty(nextDifficulty);
       setSpellingWords(shuffle(pool).slice(0, 15));
     }
   }
 
   function logScore(finalScore: number, finalCorrect: number, finalTotal: number) {
     const record: ScoreRecord = {
-      id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      id: createScoreId(),
       playerName: playerName.trim(),
       activity: activity ?? "math",
       difficulty,
       score: finalScore,
       correct: finalCorrect,
       total: finalTotal,
-      date: new Date().toLocaleDateString(),
+      date: getScoreDate(),
     };
     setScores((current) => [record, ...current].slice(0, 100));
   }
@@ -286,10 +205,11 @@ export default function LexaSlayLearningHub() {
   }
 
   function answerSpelling() {
-    if (!currentSpelling || finished) return;
+    if (!currentSpelling || finished || selected) return;
     const isCorrect = normalize(typedWord) === normalize(currentSpelling.word);
     const nextScore = score + (isCorrect ? (currentSpelling.difficulty === "Challenge" ? 20 : currentSpelling.difficulty === "Builder" ? 15 : 10) : 0);
     const nextCorrect = correct + (isCorrect ? 1 : 0);
+    setSelected(typedWord || currentSpelling.word);
     setScore(nextScore);
     setCorrect(nextCorrect);
     setFeedback(isCorrect ? "Nailed it. Dictionary domination." : `Good try. Correct spelling: ${currentSpelling.word}`);
@@ -329,7 +249,7 @@ export default function LexaSlayLearningHub() {
               <span className="flex items-center gap-3"><Crown className="h-10 w-10 text-amber-500" /> Lexa Slay Learning Quest</span>
             </CardTitle>
             <p className="max-w-3xl text-lg leading-8 text-slate-600">
-              Choose a player, take a math round or spelling round, and every completed session logs to the scoreboard. No name, no score. Tiny accountability goblin included.
+              Choose a player, take a math round or spelling round, and every completed session logs to the scoreboard. No name, no score. Tiny accountability sparkle included.
             </p>
           </CardHeader>
         </Card>
@@ -366,7 +286,7 @@ export default function LexaSlayLearningHub() {
                     <h2 className="mt-4 text-3xl font-black text-slate-950">4th Grade Spelling</h2>
                     <p className="mt-2 text-slate-600">Words are split into Starter, Builder, and Challenge sections.</p>
                     <div className="mt-5 grid gap-2">
-                      {(["Starter", "Builder", "Challenge", "Mixed"] as const).map((level) => (
+                      {SPELLING_MODES.map((level) => (
                         <Button key={level} onClick={() => startActivity("spelling", level)} variant="secondary" className="w-full justify-center">
                           <SpellCheck className="h-5 w-5" /> {level} Spelling
                         </Button>
@@ -418,7 +338,7 @@ export default function LexaSlayLearningHub() {
                     className="min-h-16 w-full rounded-[1.5rem] border-2 border-slate-200 bg-white px-5 text-2xl font-black text-slate-900 outline-none focus:border-rose-300"
                   />
                   <div className="flex flex-wrap gap-3">
-                    <Button onClick={answerSpelling} size="lg"><Sparkles className="h-5 w-5" /> Submit</Button>
+                    <Button onClick={answerSpelling} disabled={Boolean(selected)} size="lg"><Sparkles className="h-5 w-5" /> Submit</Button>
                     {feedback && <Button onClick={nextRound} variant="secondary" size="lg">Next Word</Button>}
                   </div>
                   {feedback && <div className="rounded-[1.5rem] bg-slate-100 p-4 text-lg font-bold text-slate-700">{feedback}</div>}

--- a/lib/spelling-inventory.ts
+++ b/lib/spelling-inventory.ts
@@ -1,0 +1,122 @@
+export type SpellingDifficulty = "Starter" | "Builder" | "Challenge";
+export type SpellingMode = SpellingDifficulty | "Mixed";
+
+export type SpellingWord = {
+  word: string;
+  clue: string;
+};
+
+export type SpellingPrompt = SpellingWord & {
+  difficulty: SpellingDifficulty;
+};
+
+export const SPELLING_DIFFICULTIES = ["Starter", "Builder", "Challenge"] as const;
+export const SPELLING_MODES = [...SPELLING_DIFFICULTIES, "Mixed"] as const;
+
+const SPELLING_WORD_BANK: Record<SpellingDifficulty, SpellingWord[]> = {
+  Starter: [
+    { word: "about", clue: "Concerning something" },
+    { word: "again", clue: "One more time" },
+    { word: "always", clue: "Every time" },
+    { word: "answer", clue: "A reply or solution" },
+    { word: "because", clue: "For the reason that" },
+    { word: "before", clue: "Earlier than" },
+    { word: "better", clue: "More good" },
+    { word: "between", clue: "In the middle of two things" },
+    { word: "brought", clue: "Carried with you" },
+    { word: "caught", clue: "Grabbed or captured" },
+    { word: "different", clue: "Not the same" },
+    { word: "enough", clue: "As much as needed" },
+    { word: "favorite", clue: "Liked the most" },
+    { word: "friend", clue: "Someone you like and trust" },
+    { word: "important", clue: "Matters a lot" },
+    { word: "inside", clue: "Within something" },
+    { word: "minute", clue: "Sixty seconds" },
+    { word: "people", clue: "More than one person" },
+    { word: "picture", clue: "A drawing or photo" },
+    { word: "sentence", clue: "A group of words with a complete idea" },
+    { word: "through", clue: "From one side to the other" },
+    { word: "usually", clue: "Most of the time" },
+    { word: "weather", clue: "Rain, sun, wind, and storms" },
+    { word: "without", clue: "Not having something" },
+  ],
+  Builder: [
+    { word: "although", clue: "Even though" },
+    { word: "beautiful", clue: "Very pretty" },
+    { word: "believe", clue: "To think something is true" },
+    { word: "business", clue: "A company or trade" },
+    { word: "calendar", clue: "Tracks days, weeks, and months" },
+    { word: "careful", clue: "Doing something with caution" },
+    { word: "certain", clue: "Sure or specific" },
+    { word: "complete", clue: "Finished" },
+    { word: "continue", clue: "Keep going" },
+    { word: "describe", clue: "Tell what something is like" },
+    { word: "direction", clue: "A way to go or an instruction" },
+    { word: "discover", clue: "Find something new" },
+    { word: "exercise", clue: "Activity for your body" },
+    { word: "favorite", clue: "Liked the most" },
+    { word: "finally", clue: "At last" },
+    { word: "history", clue: "Events from the past" },
+    { word: "imagine", clue: "Picture in your mind" },
+    { word: "language", clue: "Words people use to communicate" },
+    { word: "library", clue: "A place with books" },
+    { word: "measure", clue: "Find the size or amount" },
+    { word: "natural", clue: "From nature" },
+    { word: "possible", clue: "Can happen" },
+    { word: "probably", clue: "Likely" },
+    { word: "question", clue: "Something you ask" },
+    { word: "remember", clue: "Keep in your mind" },
+    { word: "separate", clue: "To keep apart" },
+    { word: "special", clue: "Not ordinary" },
+    { word: "straight", clue: "Not curved" },
+    { word: "surprise", clue: "Something unexpected" },
+    { word: "therefore", clue: "For that reason" },
+    { word: "whether", clue: "Used when comparing choices" },
+  ],
+  Challenge: [
+    { word: "accident", clue: "Something that happens by mistake" },
+    { word: "actually", clue: "Really or truly" },
+    { word: "adventure", clue: "An exciting experience" },
+    { word: "attention", clue: "Focused listening or watching" },
+    { word: "audience", clue: "People watching or listening" },
+    { word: "available", clue: "Ready to use" },
+    { word: "community", clue: "A group of people in one area" },
+    { word: "confidence", clue: "Believing you can do it" },
+    { word: "courageous", clue: "Brave" },
+    { word: "curiosity", clue: "Wanting to learn or know" },
+    { word: "dangerous", clue: "Not safe" },
+    { word: "decision", clue: "A choice" },
+    { word: "delicious", clue: "Very tasty" },
+    { word: "dictionary", clue: "A book or site with word meanings" },
+    { word: "embarrass", clue: "To make someone feel awkward" },
+    { word: "especially", clue: "More than usual" },
+    { word: "experience", clue: "Something you do or live through" },
+    { word: "experiment", clue: "A science test" },
+    { word: "government", clue: "The people who run a city, state, or country" },
+    { word: "guarantee", clue: "A promise" },
+    { word: "immediately", clue: "Right away" },
+    { word: "independent", clue: "Able to do things on your own" },
+    { word: "knowledge", clue: "What you know" },
+    { word: "necessary", clue: "Needed" },
+    { word: "occasion", clue: "A special event or time" },
+    { word: "opportunity", clue: "A chance" },
+    { word: "organization", clue: "A group or the act of arranging things" },
+    { word: "particular", clue: "Specific" },
+    { word: "performance", clue: "How well someone does" },
+    { word: "recommend", clue: "Suggest as a good choice" },
+    { word: "responsible", clue: "Trusted to handle something" },
+    { word: "schedule", clue: "A plan for when things happen" },
+    { word: "successful", clue: "Having a good result" },
+    { word: "temperature", clue: "How hot or cold something is" },
+    { word: "understand", clue: "To know what something means" },
+    { word: "wonderful", clue: "Very good" },
+  ],
+};
+
+export function getSpellingWordsForDifficulty(difficulty: SpellingDifficulty): SpellingPrompt[] {
+  return SPELLING_WORD_BANK[difficulty].map((word) => ({ ...word, difficulty }));
+}
+
+export function getAllSpellingWords(): SpellingPrompt[] {
+  return SPELLING_DIFFICULTIES.flatMap(getSpellingWordsForDifficulty);
+}


### PR DESCRIPTION
## Summary
- Fixes learning hub lint/build issues from the new scoreboard and spelling game work.
- Moves the 4th grade spelling inventory into a grouped, typed module so Starter, Builder, Challenge, and Mixed can scale without bloating the hub component.
- Removes the Google Fonts build-time network dependency while preserving the Lexa Slay styling with local playful font stacks.
- Prevents duplicate spelling submissions on the same prompt while keeping name-gated play, score logging, player totals, math, and spelling modes intact.

## Validation
- `npm run lint`
- `npm run build`
- Started the Next dev server and confirmed `http://127.0.0.1:3000` returned HTTP 200 with Lexa Slay content.